### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -20,7 +20,7 @@ jobs:
           - aarch64
 
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-45
+      image: bilelmoussaoui/flatpak-github-actions:gnome-46
       options: --privileged
 
     steps:

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up QEMU
         if: ${{ matrix.arch != 'x86_64' }}
         id: qemu
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
   


### PR DESCRIPTION
* Update docker image to runtime 46; reduces build times by a lot, especially on ARM64
* Update docker/setup-qemu-action to fix a warning

A warning about outdated artifact workflow remains; however, it comes from the flatpak action (I do not invoke it directly), so nothing can be done on my end here.