### PR TITLE
Migrate to adaptive dialogs from libadwaita 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ Note for those using `flatpak-builder`: you'll want to update git submodules as 
 
 ### Dependencies
 
-* GTK >= 4.10
-* libadwaita >= 1.4
+* GTK >= 4.13
+* libadwaita >= 1.5
 * GLib >= 2.76
 * GUsb (reasonably new)
 * libportal (optional for non-sandbox builds)

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -99,7 +99,7 @@ namespace NXDumpClient {
 		}
 
 		public async bool query_app_exit() {
-			var dialog = new Adw.MessageDialog(main_window, _("Confirm exit"), _("A file transfer is currently in progress.\nAre you sure you want to quit?")) {
+			var dialog = new Adw.AlertDialog(_("Confirm exit"), _("A file transfer is currently in progress.\nAre you sure you want to quit?")) {
 				close_response = "cancel",
 				default_response = "confirm",
 
@@ -107,7 +107,7 @@ namespace NXDumpClient {
 			dialog.add_response("cancel", C_("deny app exit", "Cancel"));
 			dialog.add_response("confirm", C_("confirm app exit", "Confirm exit"));
 			dialog.set_response_appearance("confirm", DESTRUCTIVE);
-			var res = yield dialog.choose(cancellable);
+			var res = yield dialog.choose(main_window, cancellable);
 			return res == "confirm";
 		}
 
@@ -393,10 +393,8 @@ namespace NXDumpClient {
 			main_window.present();
  			#if PROMPT_FOR_UDEV_RULES
  			if (!prompted_for_udev_rules) {
-				var udev_dialog = new UdevRulesDialog() {
-					transient_for = main_window
-				};
-				udev_dialog.present();
+				var udev_dialog = new UdevRulesDialog();
+				udev_dialog.present(main_window);
 			}
  			#endif
 		}
@@ -410,8 +408,7 @@ namespace NXDumpClient {
 		}
 
 		private void on_about_action() {
-			var about = new Adw.AboutWindow.from_appdata("/org/v1993/NXDumpClient/appdata.xml", BuildConfig.VERSION) {
-				transient_for = main_window,
+			var about = new Adw.AboutDialog.from_appdata("/org/v1993/NXDumpClient/appdata.xml", BuildConfig.VERSION) {
 				translator_credits = _("translator-credits"),
 				developers = {
 					"v19930312"
@@ -427,15 +424,13 @@ namespace NXDumpClient {
 				}
  			);
 
-			about.present();
+			about.present(main_window);
 		}
 
 		private void on_preferences_action() {
-			var preferences = new PreferencesWindow() {
-				transient_for = main_window
-			};
+			var preferences = new PreferencesDialog();
 
-			preferences.present();
+			preferences.present(main_window);
 		}
 
 		private void on_show_file_action(SimpleAction action, Variant? param)

--- a/src/PreferencesDialog.blp
+++ b/src/PreferencesDialog.blp
@@ -1,7 +1,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-template $NXDumpClientPreferencesWindow: Adw.PreferencesWindow {
+template $NXDumpClientPreferencesDialog: Adw.PreferencesDialog {
 	Adw.PreferencesPage {
 		title: _("General settings");
 

--- a/src/UdevRulesDialog.blp
+++ b/src/UdevRulesDialog.blp
@@ -1,11 +1,10 @@
 using Gtk 4.0;
 using Adw 1;
 
-template $NXDumpClientUdevRulesDialog: Adw.Window {
+template $NXDumpClientUdevRulesDialog: Adw.Dialog {
 	title: _("Udev rules installation");
-	modal: true;
 
-	content: Adw.ToolbarView {
+	child: Adw.ToolbarView {
 		[top]
 		Adw.HeaderBar {
 		}
@@ -14,21 +13,24 @@ template $NXDumpClientUdevRulesDialog: Adw.Window {
 			margin-start: 5;
 			margin-end: 5;
 			margin-bottom: 5;
+			spacing: 20;
 			orientation: vertical;
 
-			spacing: 20;
 			Label {
 				styles [ "title-4" ]
 				halign: center;
 				justify: center;
-				label: _("Udev rules must be installed for this program to work.\nPlease exectute the following command to do so:");
+				wrap: true;
+				label: _("Udev rules must be installed for this program to work. Please exectute the following command to do so:");
 			}
 
-			Label {
-				halign: center;
-				justify: center;
-				selectable: true;
-				label: bind template.command_line_for_installation;
+			Gtk.ScrolledWindow {
+				child: Label {
+					halign: center;
+					justify: center;
+					selectable: true;
+					label: bind template.command_line_for_installation;
+				};
 			}
 
 			CheckButton checkbox {

--- a/src/UdevRulesDialog.vala
+++ b/src/UdevRulesDialog.vala
@@ -21,7 +21,7 @@
 #if PROMPT_FOR_UDEV_RULES
 namespace NXDumpClient {
 	[GtkTemplate (ui = "/org/v1993/NXDumpClient/UdevRulesDialog.ui")]
-	public class UdevRulesDialog: Adw.Window {
+	public class UdevRulesDialog: Adw.Dialog {
 		protected string command_line_for_installation {
 			owned get {
 				var cmd = argv0;

--- a/src/meson.build
+++ b/src/meson.build
@@ -6,7 +6,7 @@ nxdc_sources_native = [
 
   'Application.vala',
   'Window.vala',
-  'PreferencesWindow.vala',
+  'PreferencesDialog.vala',
   'UdevRulesDialog.vala',
   'UsbContext.vala',
   'UsbDeviceClient.vala',
@@ -19,7 +19,7 @@ nxdc_sources_native = [
 
 nxdc_blueprints = files(
   'Window.blp',
-  'PreferencesWindow.blp',
+  'PreferencesDialog.blp',
   'UdevRulesDialog.blp',
 
   'gtk/help-overlay.blp',
@@ -32,8 +32,8 @@ extra_vala_args = []
 nxdc_deps = [
   dependency('glib-2.0', version: '>=2.76'),
   dependency('gio-2.0'),
-  dependency('gtk4', version: '>=4.10'),
-  dependency('libadwaita-1', version: '>= 1.4'),
+  dependency('gtk4', version: '>=4.13'),
+  dependency('libadwaita-1', version: '>= 1.5'),
 
   dependency('gusb'),
 ]

--- a/src/nxdumpclient.gresource.xml
+++ b/src/nxdumpclient.gresource.xml
@@ -2,7 +2,7 @@
 <gresources>
   <gresource prefix="/org/v1993/NXDumpClient">
     <file preprocess="xml-stripblanks">Window.ui</file>
-    <file preprocess="xml-stripblanks">PreferencesWindow.ui</file>
+    <file preprocess="xml-stripblanks">PreferencesDialog.ui</file>
     <file preprocess="xml-stripblanks">UdevRulesDialog.ui</file>
 
     <file preprocess="xml-stripblanks">gtk/help-overlay.ui</file>


### PR DESCRIPTION
See: https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/migrating-to-adaptive-dialogs.html.

Can't say I'm a huge fan of them, but they're alright. This also means that now application almost never opens another window - the only exception is the shortcuts dialog, which is still a separate window, oddly enough.