### PR TITLE
Improve metadata

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -40,7 +40,7 @@ appstream_file = i18n.merge_file(
        output: 'org.v1993.NXDumpClient.appdata.xml',
        po_dir: '../po',
       install: true,
-  install_dir: get_option('datadir') / 'appdata'
+  install_dir: get_option('datadir') / 'metainfo'
 )
 
 appstream_util = find_program('appstream-util', required: false)

--- a/data/org.v1993.NXDumpClient.appdata.xml.in
+++ b/data/org.v1993.NXDumpClient.appdata.xml.in
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
   <name>NX Dump Client</name>
-	<id>org.v1993.NXDumpClient</id>
+    <id>org.v1993.NXDumpClient</id>
   <developer_name>v19930312</developer_name>
-  <summary>Client for dumping over USB with nxdumptool</summary>
-	<metadata_license>CC0-1.0</metadata_license>
-	<project_license>GPL-3.0-or-later</project_license>
+  <summary>Dump Switch games over USB</summary>
+    <metadata_license>CC0-1.0</metadata_license>
+    <project_license>GPL-3.0-or-later</project_license>
   <translation type="gettext">nxdumpclient</translation>
   <content_rating type="oars-1.1" />
   <launchable type="desktop-id">org.v1993.NXDumpClient.desktop</launchable>
   <url type="homepage">https://github.com/v1993/nxdumpclient</url>
   <url type="bugtracker">https://github.com/v1993/nxdumpclient/issues</url>
-	<description>
-	  <p>Client for dumping over USB with nxdumptool.</p>
-	</description>
+  <description>
+    <p>This application acts as a companion to nxdumptool, allowing you to dump Nintendo Switch games directly over USB.</p>
+  </description>
   <keywords>
     <keyword>nxdumpclient</keyword>
     <keyword>nxdumptool</keyword>

--- a/data/org.v1993.NXDumpClient.appdata.xml.in
+++ b/data/org.v1993.NXDumpClient.appdata.xml.in
@@ -20,7 +20,7 @@
   </keywords>
   <screenshots>
     <screenshot type="default">
-      <caption>NX Dump Tool receiving a file</caption>
+      <caption>Receiving an NSP file</caption>
       <image type="source">https://raw.githubusercontent.com/v1993/nxdumpclient/main/data/screenshot-1.png</image>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
I'm hoping to fix the failing Flathub checks for the next release; it should be perfectly feasible.

# Progress

## Branding

- [ ] Has primary brand colors

The situation with app icon needs to be worked out first. Should be fairly easy afterwards.

## Summary

- [x] Shorter than 35 characters
- [x] Understandable for a non-technical person

Rewrote the summary (and description too). The 35 character limit is a little too tight, but whatever.

## App Name

- [ ] Just the name

Don't fix what ain't broken. This app *really* is called **NX Dump Client**; it interacts with **nxdumptool**. **NX Dump** is not a thing! You can question my naming talents, sure, but this doesn't change the fact that the app is called **NX Dump Client** and nothing else! Probably should contact flathub maintainers on [Matrix](https://matrix.to/#/#flathub:matrix.org) about this.

## App Icon

- [ ] Doesn't fill too much or too little of the canvas
- [ ] Good contrast on dark backgrounds
- [ ] In line with contemporary styles

I honestly kinda like the existing icon, but I guess it needs to be adjusted a bit. Perhaps scale it down a little and add an outline and rounded corners?

## Screenshots

- [ ] Default settings

Uh-oh, guess it's time to set up a VM? Or just another user? Because I have no idea what default settings for GNOME would be. Also, I'll want to make another screenshot with RomFS dump in progress once I'll implement full support for 1.2 ABI.

## Pre-merge

- [ ] Update translation files