### PR TITLE
Dependency updates

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -20,7 +20,8 @@ jobs:
           - aarch64
 
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-47
+      # Check for a new docker version too if you're updating this
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-48
       options: --privileged
 
     steps:
@@ -31,7 +32,12 @@ jobs:
       - name: Install deps
         if: ${{ matrix.arch != 'x86_64' }}
         run: |
-          dnf -y install docker
+          # No package manager available anymore, so grab the static binary.
+          # Yes, this sucks. Yes, this is what official docs recommend.
+          # `docker/setup-docker-action` would be really nice to use instead, but calls missing `sudo`.
+          curl https://download.docker.com/linux/static/stable/x86_64/docker-28.3.2.tgz --output ./docker.tgz
+          tar xzvf docker.tgz
+          mv docker/* /usr/bin
   
       - name: Set up QEMU
         if: ${{ matrix.arch != 'x86_64' }}

--- a/flatpak/org.v1993.NXDumpClient.yml
+++ b/flatpak/org.v1993.NXDumpClient.yml
@@ -15,6 +15,13 @@ finish-args:
   # Default dump destination
   - --filesystem=xdg-download
 
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /lib/girepository-1.0
+  - /share/gir-1.0
+  - /share/vala
+
 modules:
   - shared-modules/libusb/libusb.json
 
@@ -39,19 +46,6 @@ modules:
       - -Dtests=false
     cleanup:
       - /bin
-      - /include
-      - /lib/pkgconfig
-      - /lib/girepository-1.0
-      - /man
-      - /share/aclocal
-      - /share/doc
-      - /share/gir-1.0
-      - /share/gtk-doc
-      - /share/man
-      - /share/pkgconfig
-      - /share/vala
-      - '*.la'
-      - '*.a'
     sources:
       - type: archive
         url: https://github.com/hughsie/libgusb/releases/download/0.4.9/libgusb-0.4.9.tar.xz
@@ -70,20 +64,6 @@ modules:
       - -Dbackend-gtk4=enabled
       - -Ddocs=false
       - -Dtests=false
-    cleanup:
-      - /include
-      - /lib/pkgconfig
-      - /lib/girepository-1.0
-      - /man
-      - /share/aclocal
-      - /share/doc
-      - /share/gir-1.0
-      - /share/gtk-doc
-      - /share/man
-      - /share/pkgconfig
-      - /share/vala
-      - '*.la'
-      - '*.a'
     sources:
       - type: archive
         url: https://github.com/flatpak/libportal/releases/download/0.8.1/libportal-0.8.1.tar.xz

--- a/flatpak/org.v1993.NXDumpClient.yml
+++ b/flatpak/org.v1993.NXDumpClient.yml
@@ -25,8 +25,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.gnome.org/jwestman/blueprint-compiler.git
-        tag: v0.14.0
-        commit: 8e10fcf8692108b9d4ab78f41086c5d7773ef864
+        tag: v0.18.0
+        commit: 07c9c9df9cd1b6b4454ecba21ee58211e9144a4b
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)$

--- a/flatpak/org.v1993.NXDumpClient.yml
+++ b/flatpak/org.v1993.NXDumpClient.yml
@@ -1,7 +1,7 @@
 app-id: org.v1993.NXDumpClient
 runtime: org.gnome.Platform
 # Remember to update CI image as well
-runtime-version: '47'
+runtime-version: '48'
 sdk: org.gnome.Sdk
 command: nxdumpclient
 finish-args:

--- a/subprojects/blueprint-compiler.wrap
+++ b/subprojects/blueprint-compiler.wrap
@@ -1,8 +1,8 @@
 [wrap-file]
-directory = blueprint-compiler-v0.14.0
-source_url = https://gitlab.gnome.org/jwestman/blueprint-compiler/-/archive/v0.14.0/blueprint-compiler-v0.14.0.tar.gz
-source_filename = blueprint-compiler-v0.14.0.tar.gz
-source_hash = 05faf3810cb76d4e2d2382c6a7e6c8096af27e144e2260635c97f6a173d67234
+directory = blueprint-compiler-v0.18.0
+source_url = http://gitlab.gnome.org/jwestman/blueprint-compiler/-/archive/v0.18.0/blueprint-compiler-v0.18.0.tar.gz
+source_filename = blueprint-compiler-v0.18.0.tar.gz
+source_hash = 703c7ccd23cb6f77a8fe9c8cae0f91de9274910ca953de77135b6e79dbff1fc3
 
 [provide]
 program_names = blueprint-compiler


### PR DESCRIPTION
Looks like new Gtk has marked some shortcut-related widgets deprecated. I can look into it later.

New Flathub images are kinda weird and stripped down (manually downloading docker in particular is not great), but I guess I'll have to roll with it for the time being.