### PR TITLE
CI: Update to flatpak runtime 49

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -10,43 +10,27 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-49
+      options: --privileged
 
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - x86_64
-          - aarch64
+        variant:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
 
-    container:
-      # Check for a new docker version too if you're updating this
-      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-49
-      options: --privileged
+    runs-on: ${{ matrix.variant.runner }}
 
     steps:
       - uses: actions/checkout@v4
-      - name: Install deps
-        if: ${{ matrix.arch != 'x86_64' }}
-        run: |
-          # No package manager available anymore, so grab the static binary.
-          # Yes, this sucks. Yes, this is what official docs recommend.
-          # `docker/setup-docker-action` would be really nice to use instead, but calls missing `sudo`.
-          # TODO: use an ARM64 runner `ubuntu-24.04-arm`?
-          curl https://download.docker.com/linux/static/stable/x86_64/docker-29.3.0.tgz --output ./docker.tgz
-          tar xzvf docker.tgz
-          mv docker/* /usr/bin
-
-      - name: Set up QEMU
-        if: ${{ matrix.arch != 'x86_64' }}
-        id: qemu
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: nxdumpclient.flatpak
           manifest-path: flatpak/org.v1993.NXDumpClient.yml
           cache-key: flatpak-builder-${{ github.sha }}
-          arch: ${{ matrix.arch }}
+          arch: ${{ matrix.variant.arch }}

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -21,31 +21,29 @@ jobs:
 
     container:
       # Check for a new docker version too if you're updating this
-      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-48
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-49
       options: --privileged
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-  
       - name: Install deps
         if: ${{ matrix.arch != 'x86_64' }}
         run: |
           # No package manager available anymore, so grab the static binary.
           # Yes, this sucks. Yes, this is what official docs recommend.
           # `docker/setup-docker-action` would be really nice to use instead, but calls missing `sudo`.
-          curl https://download.docker.com/linux/static/stable/x86_64/docker-28.3.2.tgz --output ./docker.tgz
+          # TODO: use an ARM64 runner `ubuntu-24.04-arm`?
+          curl https://download.docker.com/linux/static/stable/x86_64/docker-29.3.0.tgz --output ./docker.tgz
           tar xzvf docker.tgz
           mv docker/* /usr/bin
-  
+
       - name: Set up QEMU
         if: ${{ matrix.arch != 'x86_64' }}
         id: qemu
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
-  
+
       - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: nxdumpclient.flatpak

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "flatpak/shared-modules"]
-	path = flatpak/shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ meson compile -C build
 meson install -C build
 ```
 
-An alternative to direct installation is to use flatpak manifest stored at `flatpak/org.v1993.NXDumpClient.yml` (please note that building with flatpak requires initializing git submodules; they are not used otherwise). Use of `flatpak-builder` is out-of-scope for this document - download pre-built package from Flathub if you just want to use the flatpak version.
+An alternative to direct installation is to use flatpak manifest stored at `flatpak/org.v1993.NXDumpClient.yml`. Use of `flatpak-builder` is out-of-scope for this document - download pre-built package from Flathub if you just want to use the flatpak version.
 
 ### Updating
 
@@ -71,7 +71,7 @@ meson compile -C build
 meson install -C build
 ```
 
-Note for those using `flatpak-builder`: you'll want to update git submodules as well, but can skip updating meson subprojects.
+Note for those using `flatpak-builder`: you can skip updating meson subprojects.
 
 ### Dependencies
 

--- a/flatpak/org.v1993.NXDumpClient.yml
+++ b/flatpak/org.v1993.NXDumpClient.yml
@@ -1,7 +1,7 @@
 app-id: org.v1993.NXDumpClient
 runtime: org.gnome.Platform
 # Remember to update CI image as well
-runtime-version: '48'
+runtime-version: '49'
 sdk: org.gnome.Sdk
 command: nxdumpclient
 finish-args:
@@ -23,22 +23,6 @@ cleanup:
   - /share/vala
 
 modules:
-  - shared-modules/libusb/libusb.json
-
-  - name: blueprint-compiler
-    buildsystem: meson
-    cleanup:
-      - '*'
-    sources:
-      - type: git
-        url: https://gitlab.gnome.org/jwestman/blueprint-compiler.git
-        tag: v0.18.0
-        commit: 07c9c9df9cd1b6b4454ecba21ee58211e9144a4b
-        x-checker-data:
-          type: git
-          tag-pattern: ^v([\d.]+)$
-          version-scheme: semantic
-
   - name: libgusb
     buildsystem: meson
     config-opts:


### PR DESCRIPTION
Update to what Flathub build has already been using, allowing us to drop the shared-modules submodule. Also switch to GitHub's ARM64 runner.