### PR TITLE
Remove a wrap for blueprint-compiler

### DIFF
--- a/README-MSYS2.md
+++ b/README-MSYS2.md
@@ -15,6 +15,7 @@ Install *everything* but stuff like `git` with the environment-specific prefix. 
 ```bash
 git
 ${MINGW_PACKAGE_PREFIX}-desktop-file-utils
+${MINGW_PACKAGE_PREFIX}-blueprint-compiler
 ${MINGW_PACKAGE_PREFIX}-gtk4
 ${MINGW_PACKAGE_PREFIX}-libadwaita
 ${MINGW_PACKAGE_PREFIX}-libgusb

--- a/README.md
+++ b/README.md
@@ -66,12 +66,9 @@ An alternative to direct installation is to use flatpak manifest stored at `flat
 ```bash
 cd nxdumpclient
 git pull
-meson subprojects update
 meson compile -C build
 meson install -C build
 ```
-
-Note for those using `flatpak-builder`: you can skip updating meson subprojects.
 
 ### Dependencies
 
@@ -80,4 +77,4 @@ Note for those using `flatpak-builder`: you can skip updating meson subprojects.
 * GLib >= 2.80
 * GUsb (reasonably new)
 * libportal (optional for non-sandbox builds)
-* blueprint-compiler >= 0.10 (build-only; automatically fetched by meson if not available)
+* blueprint-compiler (build-only)

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,5 +1,0 @@
-*
-
-!.gitignore
-!packagefiles/**
-!*.wrap

--- a/subprojects/blueprint-compiler.wrap
+++ b/subprojects/blueprint-compiler.wrap
@@ -1,8 +1,0 @@
-[wrap-file]
-directory = blueprint-compiler-v0.18.0
-source_url = http://gitlab.gnome.org/jwestman/blueprint-compiler/-/archive/v0.18.0/blueprint-compiler-v0.18.0.tar.gz
-source_filename = blueprint-compiler-v0.18.0.tar.gz
-source_hash = 703c7ccd23cb6f77a8fe9c8cae0f91de9274910ca953de77135b6e79dbff1fc3
-
-[provide]
-program_names = blueprint-compiler


### PR DESCRIPTION
blueprint-compiler appears to be readily available nowadays and neither AUR nor flatpak builds rely on installation via the wrap file. As such, remove a largely unmaintained feature. I could add it back if there's demand, but I don't expect there to be any.